### PR TITLE
Use parseEnv instead of getAlias

### DIFF
--- a/src/services/Download.php
+++ b/src/services/Download.php
@@ -168,7 +168,7 @@ class Download extends Component
 
             // Get volume and folder paths
             $volumeSettings = $asset->getVolume()->getSettings();
-            $volumePath = Craft::getAlias($volumeSettings['path']).'/';
+            $volumePath = Craft::parseEnv($volumeSettings['path']).'/';
             $folderPath = $asset->getFolder()->path.'/';
 
             // Set local path (prevent double slashes)


### PR DESCRIPTION
This wil not only check for environmental variables but also for aliasses if no environmental variables are to be found.